### PR TITLE
PortableDID refactoring part 1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,8 @@ let package = Package(
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", from: "0.7.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "1.1.2"),
         .package(url: "https://github.com/WeTransfer/Mocker.git", .upToNextMajor(from: "3.0.1")),
-        .package(url: "https://github.com/allegro/swift-junit.git", from: "2.1.0")
+        .package(url: "https://github.com/allegro/swift-junit.git", from: "2.1.0"),
+        .package(url: "https://github.com/flight-school/anycodable.git", from: "0.6.7"),
     ],
     targets: [
         .target(
@@ -26,11 +27,15 @@ let package = Package(
             dependencies: [
                 .product(name: "secp256k1", package: "secp256k1.swift"),
                 .product(name: "ExtrasBase64", package: "swift-extras-base64"),
+                .product(name: "AnyCodable", package: "anycodable"),
             ]
         ),
         .testTarget(
             name: "Web5Tests",
-            dependencies: ["Web5"]
+            dependencies: [
+                "Web5",
+                .product(name: "CustomDump", package: "swift-custom-dump"),
+            ]
         ),
         .testTarget(
             name: "Web5TestVectors",

--- a/Sources/Web5/Dids/DID.swift
+++ b/Sources/Web5/Dids/DID.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Decentralized Identifier (DID), according to the  [W3C DID Core specification](https://www.w3.org/TR/did-core).
-public struct DID {
+public struct DID: Equatable {
 
     /// Represents the complete Decentralized Identifier (DID) URI
     ///

--- a/Sources/Web5/Dids/PortableDID.swift
+++ b/Sources/Web5/Dids/PortableDID.swift
@@ -1,16 +1,24 @@
+import AnyCodable
 import Foundation
 
+/// A representation of a `BearerDID` that can be moved imported/exported.
+///
+/// `PortableDID` bundles all of the necessary information for a `BearerDID`,
+/// enabling the usage of the DID in different context. This format is compatible
+/// and interoperable across all Web5 programming languages.
 public struct PortableDID: Codable {
+
+    public typealias Metadata = [String: AnyCodable]
+
+    /// URI of DID
     let uri: String
-    let verificationMethods: [VerificationMethodKeyPair]
 
-    public struct VerificationMethodKeyPair: Codable {
-        let publicKey: Jwk
-        let privateKey: Jwk
+    /// `DIDDocument` of the DID
+    let document: DIDDocument
 
-        enum CodingKeys: String, CodingKey {
-            case publicKey = "publicKeyJwk"
-            case privateKey = "privateKeyJwk"
-        }
-    }
+    /// Private keys that correspond to the public keys present in the `document`
+    let privateKeys: [Jwk]
+
+    /// Additional DID method specific information to be included
+    let metadata: Metadata?
 }

--- a/Tests/Web5Tests/Dids/BearerDIDTests.swift
+++ b/Tests/Web5Tests/Dids/BearerDIDTests.swift
@@ -1,22 +1,17 @@
+import CustomDump
 import XCTest
 
 @testable import Web5
 
 final class BearerDIDTests: XCTestCase {
 
-    func test_toKeys() async throws {
+    func test_export() async throws {
         let didJWK = try DIDJWK.create(keyManager: InMemoryKeyManager())
-        let portableDID = try await didJWK.toPortableDID()
+        let portableDID = try await didJWK.export()
 
-        XCTAssertEqual(portableDID.uri, didJWK.uri)
-        XCTAssertEqual(portableDID.verificationMethods.count, 1)
+        XCTAssertNoDifference(portableDID.uri, didJWK.uri)
+        XCTAssertNoDifference(portableDID.document, didJWK.document)
+        XCTAssertNoDifference(portableDID.privateKeys.count, 1)
+        XCTAssertNil(portableDID.metadata)
     }
-
-    func test_initializeWithKeys() async throws {
-        let didJWK = try DIDJWK.create(keyManager: InMemoryKeyManager())
-        let portableDID = try await didJWK.toPortableDID()
-
-        XCTAssertNoThrow(try BearerDID(portableDID: portableDID))
-    }
-
 }

--- a/Tests/Web5Tests/Dids/DIDJWKTests.swift
+++ b/Tests/Web5Tests/Dids/DIDJWKTests.swift
@@ -1,3 +1,4 @@
+import CustomDump
 import XCTest
 
 @testable import Web5
@@ -71,6 +72,21 @@ final class DIDJWKTests: XCTestCase {
         XCTAssertEqual(resolutionResult.didDocument?.capabilityDelegation?.first, .referenced("\(didURI)#0"))
         XCTAssertEqual(resolutionResult.didDocument?.capabilityInvocation?.first, .referenced("\(didURI)#0"))
         XCTAssertNil(resolutionResult.didResolutionMetadata.error)
+    }
+
+    func test_import() throws {
+        let keyManager = InMemoryKeyManager()
+        let bearerDID = try DIDJWK.create(keyManager: keyManager)
+        let portableDID = try bearerDID.export()
+
+        let importedBearerDID = try DIDJWK.import(
+            portableDID: portableDID,
+            keyManager: keyManager
+        )
+
+        XCTAssertNoDifference(importedBearerDID.did, bearerDID.did)
+        XCTAssertNoDifference(importedBearerDID.document, bearerDID.document)
+        XCTAssertNoDifference(importedBearerDID.metadata, importedBearerDID.metadata)
     }
 
 }


### PR DESCRIPTION
First part in the changes to DID creation, PortableDID, and BearerDID from [here](https://github.com/TBD54566975/web5-spec/issues/112).

This PR addressed the following refactoring areas:
* `BearerDID` now contains the following properties:
    * `uri` - the DID URI represented
    * `document` - the full `DIDDocument` for the `BearerDID`
    * `keyManager` - the `KeyManager` where the backing private keys are stored
    * `metadata` - a grab bag dictionary/map that can store method-specific information
* `BearerDID` can now be exported via the `export()` function, which returns a `PortableDID`
* `PortableDID` can be imported via a DID Method
    * `DIDJWK` is the only method currently implemented that can import
    * `import()` takes in an exported `PortableDID`, and an optional `KeyManager` to store the private keys into
    
I will address the following in a follow-up PR:
* `BearerDID` needs to expose a `getSigner` function