### PR TITLE
BearerDID `getSigner` function

### DIFF
--- a/Tests/Web5Tests/Dids/BearerDIDTests.swift
+++ b/Tests/Web5Tests/Dids/BearerDIDTests.swift
@@ -15,7 +15,7 @@ final class BearerDIDTests: XCTestCase {
         XCTAssertNil(portableDID.metadata)
     }
 
-    func test_signAndVerify() throws {
+    func test_getSigner() throws {
         let payload = "Hello, world!".data(using: .utf8)!
 
         let didJWK = try DIDJWK.create(keyManager: InMemoryKeyManager())
@@ -25,5 +25,23 @@ final class BearerDIDTests: XCTestCase {
         let isValid = try signer.verify(payload: payload, signature: signature)
 
         XCTAssertTrue(isValid)
+    }
+
+    func test_getSigner_verificationMethodID() throws {
+        let payload = "Hello, world!".data(using: .utf8)!
+
+        let didJWK = try DIDJWK.create(keyManager: InMemoryKeyManager())
+        let verificationMethodID = try XCTUnwrap(didJWK.document.verificationMethod?.first?.id)
+
+        let signer = try didJWK.getSigner(verificationMethodID: verificationMethodID)
+        let signature = try signer.sign(payload: payload)
+        let isValid = try signer.verify(payload: payload, signature: signature)
+
+        XCTAssertTrue(isValid)
+    }
+
+    func test_getSigner_invalidVerificationMethodID() throws {
+        let didJWK = try DIDJWK.create(keyManager: InMemoryKeyManager())
+        XCTAssertThrowsError(try didJWK.getSigner(verificationMethodID: "not-real"))
     }
 }

--- a/Tests/Web5Tests/Dids/BearerDIDTests.swift
+++ b/Tests/Web5Tests/Dids/BearerDIDTests.swift
@@ -5,13 +5,25 @@ import XCTest
 
 final class BearerDIDTests: XCTestCase {
 
-    func test_export() async throws {
+    func test_export() throws {
         let didJWK = try DIDJWK.create(keyManager: InMemoryKeyManager())
-        let portableDID = try await didJWK.export()
+        let portableDID = try didJWK.export()
 
         XCTAssertNoDifference(portableDID.uri, didJWK.uri)
         XCTAssertNoDifference(portableDID.document, didJWK.document)
         XCTAssertNoDifference(portableDID.privateKeys.count, 1)
         XCTAssertNil(portableDID.metadata)
+    }
+
+    func test_signAndVerify() throws {
+        let payload = "Hello, world!".data(using: .utf8)!
+
+        let didJWK = try DIDJWK.create(keyManager: InMemoryKeyManager())
+        let signer = try didJWK.getSigner()
+
+        let signature = try signer.sign(payload: payload)
+        let isValid = try signer.verify(payload: payload, signature: signature)
+
+        XCTAssertTrue(isValid)
     }
 }


### PR DESCRIPTION
Depends on [part 1](https://github.com/TBD54566975/web5-swift/pull/6)

Adds a `getSigner` function to `BearerDID`. It can be called in the following way:
```swift
let didJWK = try DIDJWK.create(keyManager: InMemoryKeyManager())
let signer = try didJWK.getSigner()

let signature = try signer.sign(payload: payload)
let isValid = try signer.verify(payload: payload, signature: signature)
```

You can also provide an optional `verificationMethodID`, which can be used to specify which verification method to use with the signer. If it's an invalid verification method identifier, the function will throw an error. Example usage:

```swift
let didJWK = try DIDJWK.create(keyManager: InMemoryKeyManager())
let signer = try didJWK.getSigner(verificationMethodID: "1234")

let signature = try signer.sign(payload: payload)
let isValid = try signer.verify(payload: payload, signature: signature)
```