### PR TITLE
Add explicit protocols for DIDMethod, DIDMethodResolver, and DIDMethodCreator

### DIFF
--- a/Sources/Web5/Dids/BearerDID.swift
+++ b/Sources/Web5/Dids/BearerDID.swift
@@ -55,7 +55,7 @@ public struct BearerDID {
     ///   - keyAlias: Alias of the key that will be used for
     public func getSigner(verificationMethodID: String? = nil) throws -> BearerDIDSigner {
         let verificationMethod: VerificationMethod?
-        
+
         if let verificationMethodID {
             verificationMethod = document.verificationMethod?.first { $0.id == verificationMethodID }
         } else {
@@ -142,7 +142,7 @@ public struct BearerDIDSigner {
     where P: DataProtocol {
         return try self.keyManager.sign(keyAlias: keyAlias, payload: payload)
     }
-    
+
     public func verify<P, S>(payload: P, signature: S) throws -> Bool
     where P: DataProtocol, S: DataProtocol {
         let publicKey = try keyManager.getPublicKey(keyAlias: keyAlias)

--- a/Sources/Web5/Dids/Methods/DIDIon.swift
+++ b/Sources/Web5/Dids/Methods/DIDIon.swift
@@ -1,13 +1,24 @@
 import Foundation
 
-enum DIDIon {
+/// `did:ion` DID Method
+public enum DIDIon: DIDMethod {
 
     public static let methodName = "ion"
+}
+
+// MARK: - DIDMethodResolver
+
+extension DIDIon: DIDMethodResolver {
 
     /// Resolves a `did:ion` URI into a `DIDResolutionResult`
-    /// - Parameter didURI: The DID URI to resolve
+    /// - Parameters:
+    ///   - didURI: The DID URI to resolve
+    ///   - options: The options to use when resolving the DID URI
     /// - Returns: `DIDResolutionResult` containing the resolved DID Document.
-    static func resolve(didURI: String) async -> DIDResolutionResult {
+    public static func resolve(
+        didURI: String,
+        options: DIDMethodResolutionOptions? = nil
+    ) async -> DIDResolutionResult {
         guard let did = try? DID(didURI: didURI) else {
             return DIDResolutionResult(error: .invalidDID)
         }
@@ -28,7 +39,5 @@ enum DIDIon {
         } catch {
             return DIDResolutionResult(error: .notFound)
         }
-
     }
-
 }

--- a/Sources/Web5/Dids/Methods/DIDIon.swift
+++ b/Sources/Web5/Dids/Methods/DIDIon.swift
@@ -13,11 +13,9 @@ extension DIDIon: DIDMethodResolver {
     /// Resolves a `did:ion` URI into a `DIDResolutionResult`
     /// - Parameters:
     ///   - didURI: The DID URI to resolve
-    ///   - options: The options to use when resolving the DID URI
     /// - Returns: `DIDResolutionResult` containing the resolved DID Document.
     public static func resolve(
-        didURI: String,
-        options: DIDMethodResolutionOptions? = nil
+        didURI: String
     ) async -> DIDResolutionResult {
         guard let did = try? DID(didURI: didURI) else {
             return DIDResolutionResult(error: .invalidDID)

--- a/Sources/Web5/Dids/Methods/DIDJWK.swift
+++ b/Sources/Web5/Dids/Methods/DIDJWK.swift
@@ -13,11 +13,9 @@ extension DIDJWK: DIDMethodResolver {
     /// Resolves a `did:jwk` URI into a `DIDResolutionResult`
     /// - Parameters:
     ///   - didURI: The DID URI to resolve
-    ///   - options: The options to use when resolving the DID URI
     /// - Returns: `DIDResolution.Result` containing the resolved DID Document
     public static func resolve(
-        didURI: String,
-        options: DIDMethodResolutionOptions? = nil
+        didURI: String
     ) async -> DIDResolutionResult {
         guard let did = try? DID(didURI: didURI),
             let jwk = try? JSONDecoder().decode(Jwk.self, from: try did.identifier.decodeBase64Url())
@@ -41,15 +39,16 @@ extension DIDJWK: DIDMethodCreator {
     /// Options that can be provided to customize how a `did:jwk` is created
     public struct CreateOptions {
 
+        /// Default options to use when creating a `did:jwk`
+        public static let `default` = CreateOptions(
+            algorithm: .ed25519
+        )
+
         /// The algorithm to use when creating the backing key for the DID
         public let algorithm: CryptoAlgorithm
 
-        /// Default Initializer
-        /// - Parameters
-        ///   - algorithm: The algorithm to use when creating the backing key for the DID.
-        ///   Defaults to `.ed25519` if not specified.
         public init(
-            algorithm: CryptoAlgorithm = .ed25519
+            algorithm: CryptoAlgorithm
         ) {
             self.algorithm = algorithm
         }
@@ -59,11 +58,11 @@ extension DIDJWK: DIDMethodCreator {
     ///
     /// - Parameters:
     ///   - keyManager: `KeyManager` used to generate and store the keys associated to the DID
-    ///   - options: Options configuring how the DIDJWK is created. Uses default if not specified.
+    ///   - options: Options configuring how the DIDJWK is created
     /// - Returns: `BearerDID` that represents the created DIDJWK
     public static func create(
         keyManager: KeyManager,
-        options: CreateOptions = .init()
+        options: CreateOptions
     ) throws -> BearerDID {
         let keyAlias = try keyManager.generatePrivateKey(algorithm: options.algorithm)
         let publicKey = try keyManager.getPublicKey(keyAlias: keyAlias)
@@ -77,6 +76,21 @@ extension DIDJWK: DIDMethodCreator {
             did: did,
             document: document,
             keyManager: keyManager
+        )
+    }
+
+    /// Create a new `BearerDID` using the `did:jwk` method.
+    ///
+    /// - Parameters:
+    ///   - keyManager: `KeyManager` used to generate and store the keys associated to the DID
+    /// - Returns: `BearerDID` that represents the created DIDJWK
+    public static func create(
+        keyManager: KeyManager
+    ) throws -> BearerDID {
+        // Create a new `BearerDID` using default options
+        return try create(
+            keyManager: keyManager,
+            options: CreateOptions.default
         )
     }
 

--- a/Sources/Web5/Dids/Methods/DIDWeb.swift
+++ b/Sources/Web5/Dids/Methods/DIDWeb.swift
@@ -1,15 +1,24 @@
 import Foundation
 
-enum DIDWeb {
+/// `did:web` DID Method
+enum DIDWeb: DIDMethod {
 
     public static let methodName = "web"
+}
 
-    // MARK: - Public Static
+// MARK: - DIDMethodResolver
 
-    /// Resolves a `did:jwk` URI into a `DIDResolutionResult`
-    /// - Parameter didURI: The DID URI to resolve
-    /// - Returns: `DIDResolution.Result` containing the resolved DID Document.
-    static func resolve(didURI: String) async -> DIDResolutionResult {
+extension DIDWeb: DIDMethodResolver {
+
+    /// Resolves a `did:web` URI into a `DIDResolutionResult`
+    /// - Parameters:
+    ///   - didURI: The DID URI to resolve
+    ///   - options: The options to use when resolving the DID URI
+    /// - Returns: `DIDResolution.Result` containing the resolved DID Document
+    static func resolve(
+        didURI: String,
+        options: DIDMethodResolutionOptions? = nil
+    ) async -> DIDResolutionResult {
         guard let did = try? DID(didURI: didURI),
             let url = getDIDDocumentUrl(did: did)
         else {
@@ -28,8 +37,6 @@ enum DIDWeb {
             return DIDResolutionResult(error: .notFound)
         }
     }
-
-    // MARK: - Private Static
 
     private static let wellKnownPath = "/.well-known"
     private static let didDocumentFilename = "/did.json"

--- a/Sources/Web5/Dids/Methods/DIDWeb.swift
+++ b/Sources/Web5/Dids/Methods/DIDWeb.swift
@@ -13,11 +13,9 @@ extension DIDWeb: DIDMethodResolver {
     /// Resolves a `did:web` URI into a `DIDResolutionResult`
     /// - Parameters:
     ///   - didURI: The DID URI to resolve
-    ///   - options: The options to use when resolving the DID URI
     /// - Returns: `DIDResolution.Result` containing the resolved DID Document
     static func resolve(
-        didURI: String,
-        options: DIDMethodResolutionOptions? = nil
+        didURI: String
     ) async -> DIDResolutionResult {
         guard let did = try? DID(didURI: didURI),
             let url = getDIDDocumentUrl(did: did)
@@ -41,7 +39,9 @@ extension DIDWeb: DIDMethodResolver {
     private static let wellKnownPath = "/.well-known"
     private static let didDocumentFilename = "/did.json"
 
-    private static func getDIDDocumentUrl(did: DID) -> URL? {
+    private static func getDIDDocumentUrl(
+        did: DID
+    ) -> URL? {
         let domainNameWithPath = did.identifier.replacingOccurrences(of: ":", with: "/")
         guard let decodedDomain = domainNameWithPath.removingPercentEncoding,
             var url = URL(string: "https://\(decodedDomain)")

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethod.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethod.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Protocol defining all common behaviors required for every DID Method
+public protocol DIDMethod {
+
+    /// The name of the DID Method.
+    ///
+    /// For example, in the DID URI `did:example:123456`, `example` would be the method name.
+    static var methodName: String { get }
+}

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethodCreator.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethodCreator.swift
@@ -3,21 +3,16 @@ import Foundation
 /// Protocol defining the behaviors required for a DID Method to construct DIDs
 public protocol DIDMethodCreator: DIDMethod {
 
-    /// The type of options used when creating DIDs. Each DID method should define its own options type.
-    associatedtype CreateOptions
-
     /// Creates a new `BearerDID` using the target DID Method
     ///
     /// This function should generate a new `BearerDID` in accordance with the DID Method
-    /// specification being implemented, using the provided `keyManager` and `options`.
+    /// specification being implemented, using the provided `keyManager`.
     ///
     /// - Parameters:
     ///   - keyManager: `KeyManager` used to generate and store the keys associated to the DID
-    ///   - options: Options configuring how the DID is created.
     /// - Returns: `BearerDID` which can be used to sign & verify data
     static func create(
-        keyManager: KeyManager,
-        options: CreateOptions
+        keyManager: KeyManager
     ) throws -> BearerDID
 
     /// Import a `PortableDID`, which represents the target DID Method, into a `BearerDID`

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethodCreator.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethodCreator.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Protocol defining the behaviors required for a DID Method to construct DIDs
+public protocol DIDMethodCreator: DIDMethod {
+
+    /// The type of options used when creating DIDs. Each DID method should define its own options type.
+    associatedtype CreateOptions
+
+    /// Creates a new `BearerDID` using the target DID Method
+    ///
+    /// This function should generate a new `BearerDID` in accordance with the DID Method
+    /// specification being implemented, using the provided `keyManager` and `options`.
+    ///
+    /// - Parameters:
+    ///   - keyManager: `KeyManager` used to generate and store the keys associated to the DID
+    ///   - options: Options configuring how the DID is created.
+    /// - Returns: `BearerDID` which can be used to sign & verify data
+    static func create(
+        keyManager: KeyManager,
+        options: CreateOptions
+    ) throws -> BearerDID
+
+    /// Import a `PortableDID`, which represents the target DID Method, into a `BearerDID`
+    ///
+    /// - Parameters:
+    ///   - keyManager: `KeyManager` used to generate and store the keys associated to the DID
+    ///   - portableDID: `PortableDID` to import into a `BearerDID`
+    /// - Returns: `BearerDID` which can be used to sign & verify data
+    static func `import`(
+        keyManager: KeyManager,
+        portableDID: PortableDID
+    ) throws -> BearerDID
+}

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
@@ -7,16 +7,8 @@ public protocol DIDMethodResolver: DIDMethod {
     ///
     /// - Parameters:
     ///   - didURI: The DID URI to resolve
-    ///   - options: The options to use when resolving the DID URI
     /// - Returns: `DIDResolutionResult` containing the resolved DID Document
     static func resolve(
-        didURI: String,
-        options: DIDMethodResolutionOptions?
+        didURI: String
     ) async -> DIDResolutionResult
 }
-
-
-/// Protocol defining the options that are available to configure when resolving a DID Method.
-/// Each DID Method should define its own options type conforming to this protocol, if it has
-/// method-specific customization options.
-public protocol DIDMethodResolutionOptions {}

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Protocol defining the behaviors required to resolve a DID Method
+public protocol DIDMethodResolver: DIDMethod {
+
+    /// Resolve a DID URI into a `DIDResolutionResult`, containing the resolved DID Document
+    ///
+    /// - Parameters:
+    ///   - didURI: The DID URI to resolve
+    ///   - options: The options to use when resolving the DID URI
+    /// - Returns: `DIDResolutionResult` containing the resolved DID Document
+    static func resolve(
+        didURI: String,
+        options: DIDMethodResolutionOptions?
+    ) async -> DIDResolutionResult
+}
+
+
+/// Protocol defining the options that are available to configure when resolving a DID Method.
+/// Each DID Method should define its own options type conforming to this protocol, if it has
+/// method-specific customization options.
+public protocol DIDMethodResolutionOptions {}

--- a/Sources/Web5/Dids/Resolution/DIDResolver.swift
+++ b/Sources/Web5/Dids/Resolution/DIDResolver.swift
@@ -9,10 +9,7 @@ public enum DIDResolver {
     ]
 
     /// Resolves a DID URI to its DID Document
-    public static func resolve(
-        didURI: String,
-        options: DIDMethodResolutionOptions? = nil
-    ) async -> DIDResolutionResult {
+    public static func resolve(didURI: String) async -> DIDResolutionResult {
         guard let did = try? DID(didURI: didURI) else {
             return DIDResolutionResult(error: .invalidDID)
         }
@@ -21,6 +18,6 @@ public enum DIDResolver {
             return DIDResolutionResult(error: .methodNotSupported)
         }
 
-        return await methodResolver.resolve(didURI: didURI, options: options)
+        return await methodResolver.resolve(didURI: didURI)
     }
 }

--- a/Sources/Web5/Dids/Resolution/DIDResolver.swift
+++ b/Sources/Web5/Dids/Resolution/DIDResolver.swift
@@ -1,17 +1,18 @@
 import Foundation
 
-typealias DIDMethodResolver = (String) async -> DIDResolutionResult
-
 public enum DIDResolver {
 
-    private static var methodResolvers: [String: DIDMethodResolver] = [
-        DIDJWK.methodName: DIDJWK.resolve,
-        DIDWeb.methodName: DIDWeb.resolve,
-        DIDIon.methodName: DIDIon.resolve,
+    private static var methodResolvers: [String: any DIDMethodResolver.Type] = [
+        DIDIon.methodName: DIDIon.self,
+        DIDJWK.methodName: DIDJWK.self,
+        DIDWeb.methodName: DIDWeb.self,
     ]
 
     /// Resolves a DID URI to its DID Document
-    public static func resolve(didURI: String) async -> DIDResolutionResult {
+    public static func resolve(
+        didURI: String,
+        options: DIDMethodResolutionOptions? = nil
+    ) async -> DIDResolutionResult {
         guard let did = try? DID(didURI: didURI) else {
             return DIDResolutionResult(error: .invalidDID)
         }
@@ -20,7 +21,6 @@ public enum DIDResolver {
             return DIDResolutionResult(error: .methodNotSupported)
         }
 
-        return await methodResolver(didURI)
+        return await methodResolver.resolve(didURI: didURI, options: options)
     }
-
 }

--- a/Sources/Web5/Dids/Resolution/DIDResolver.swift
+++ b/Sources/Web5/Dids/Resolution/DIDResolver.swift
@@ -2,14 +2,16 @@ import Foundation
 
 public enum DIDResolver {
 
-    private static var methodResolvers: [String: any DIDMethodResolver.Type] = [
+    private static var methodResolvers: [String: DIDMethodResolver.Type] = [
         DIDIon.methodName: DIDIon.self,
         DIDJWK.methodName: DIDJWK.self,
         DIDWeb.methodName: DIDWeb.self,
     ]
 
     /// Resolves a DID URI to its DID Document
-    public static func resolve(didURI: String) async -> DIDResolutionResult {
+    public static func resolve(
+        didURI: String
+    ) async -> DIDResolutionResult {
         guard let did = try? DID(didURI: didURI) else {
             return DIDResolutionResult(error: .invalidDID)
         }

--- a/Tests/Web5Tests/Dids/DIDJWKTests.swift
+++ b/Tests/Web5Tests/Dids/DIDJWKTests.swift
@@ -80,8 +80,8 @@ final class DIDJWKTests: XCTestCase {
         let portableDID = try bearerDID.export()
 
         let importedBearerDID = try DIDJWK.import(
-            portableDID: portableDID,
-            keyManager: keyManager
+            keyManager: keyManager,
+            portableDID: portableDID
         )
 
         XCTAssertNoDifference(importedBearerDID.did, bearerDID.did)


### PR DESCRIPTION
Adding three protocols that define DID Method behaviors:
* `DIDMethod`
* `DIDMethodResolver`
* `DIDMethodCreator`

Each DID Method implementation should conform the the appropriate protocol, depending on what functionality it is implementing. This will give us a consistent interface to interact with DID Methods, preventing minor inconsistencies that can creep up such as naming, parameter ordering, etc.