### PR TITLE
Key id rename

### DIFF
--- a/Sources/Web5/Crypto/DigitalSignatureAlgorithms/ECDSA+Es256k.swift
+++ b/Sources/Web5/Crypto/DigitalSignatureAlgorithms/ECDSA+Es256k.swift
@@ -148,7 +148,7 @@ extension secp256k1.Signing.PublicKey {
             y: y.base64UrlEncodedString()
         )
 
-        jwk.keyIdentifier = try jwk.thumbprint()
+        jwk.keyID = try jwk.thumbprint()
         return jwk
     }
 

--- a/Sources/Web5/Crypto/DigitalSignatureAlgorithms/EdDSA+Ed25519.swift
+++ b/Sources/Web5/Crypto/DigitalSignatureAlgorithms/EdDSA+Ed25519.swift
@@ -110,7 +110,7 @@ extension Curve25519.Signing.PublicKey {
             curve: .ed25519,
             x: rawRepresentation.base64UrlEncodedString()
         )
-        jwk.keyIdentifier = try jwk.thumbprint()
+        jwk.keyID = try jwk.thumbprint()
 
         return jwk
     }

--- a/Sources/Web5/Crypto/JOSE/JWK.swift
+++ b/Sources/Web5/Crypto/JOSE/JWK.swift
@@ -60,8 +60,8 @@ public struct Jwk: Codable, Equatable {
     /// The `alg` (algorithm) parameter identifies the cryptographic algorithm intended for use with the key.
     public internal(set) var algorithm: Algorithm?
 
-    /// The "alg" (algorithm) parameter identifies the algorithm intended for use with the key.
-    public internal(set) var keyIdentifier: String?
+    /// The `kid` (key ID) parameter identifies the algorithm intended for use with the key.
+    public internal(set) var keyID: String?
 
     /// The `crv` (curve) parameter identifies the cryptographic curve intended for use with the key.
     public internal(set) var curve: Curve?
@@ -104,7 +104,7 @@ public struct Jwk: Codable, Equatable {
         publicKeyUse: PublicKeyUse? = nil,
         keyOperations: [KeyOperations]? = nil,
         algorithm: Algorithm? = nil,
-        keyIdentifier: String? = nil,
+        keyID: String? = nil,
         curve: Curve? = nil,
         x509Url: String? = nil,
         x509CertificateChain: String? = nil,
@@ -118,7 +118,7 @@ public struct Jwk: Codable, Equatable {
         self.publicKeyUse = publicKeyUse
         self.keyOperations = keyOperations
         self.algorithm = algorithm
-        self.keyIdentifier = keyIdentifier
+        self.keyID = keyID
         self.curve = curve
         self.x509Url = x509Url
         self.x509CertificateChain = x509CertificateChain
@@ -136,7 +136,7 @@ public struct Jwk: Codable, Equatable {
         case publicKeyUse = "use"
         case keyOperations = "key_ops"
         case algorithm = "alg"
-        case keyIdentifier = "kid"
+        case keyID = "kid"
         case curve = "crv"
         case x509Url = "x5u"
         case x509CertificateChain = "x5c"

--- a/Sources/Web5/Crypto/KeyManager/Local/LocalKeyManager.swift
+++ b/Sources/Web5/Crypto/KeyManager/Local/LocalKeyManager.swift
@@ -40,8 +40,8 @@ public class LocalKeyManager: KeyManager {
     public func getDeterministicAlias(key: Jwk) throws -> String {
         let alias: String
 
-        if let keyIdentifier = key.keyIdentifier {
-            alias = keyIdentifier
+        if let keyID = key.keyID {
+            alias = keyID
         } else {
             alias = try key.thumbprint()
         }

--- a/Tests/Web5Tests/Crypto/DigitalSignatureAlgorithms/ECDSA+Es256kTests.swift
+++ b/Tests/Web5Tests/Crypto/DigitalSignatureAlgorithms/ECDSA+Es256kTests.swift
@@ -12,7 +12,7 @@ final class ECDSA_Es256kTests: XCTestCase {
 
         XCTAssertEqual(privateKey.curve, .secp256k1)
         XCTAssertEqual(privateKey.keyType, .elliptic)
-        XCTAssertNotNil(privateKey.keyIdentifier)
+        XCTAssertNotNil(privateKey.keyID)
         XCTAssertNotNil(privateKey.d)
         XCTAssertNotNil(privateKey.x)
         XCTAssertNotNil(privateKey.y)
@@ -24,14 +24,14 @@ final class ECDSA_Es256kTests: XCTestCase {
 
         XCTAssertEqual(publicKey.curve, .secp256k1)
         XCTAssertEqual(publicKey.keyType, .elliptic)
-        XCTAssertNotNil(publicKey.keyIdentifier)
+        XCTAssertNotNil(publicKey.keyID)
         XCTAssertNil(publicKey.d)
         XCTAssertNotNil(publicKey.x)
         XCTAssertNotNil(publicKey.y)
 
         XCTAssertEqual(publicKey.curve, privateKey.curve)
         XCTAssertEqual(publicKey.keyType, privateKey.keyType)
-        XCTAssertEqual(publicKey.keyIdentifier, privateKey.keyIdentifier)
+        XCTAssertEqual(publicKey.keyID, privateKey.keyID)
         XCTAssertEqual(publicKey.x, privateKey.x)
         XCTAssertEqual(publicKey.y, privateKey.y)
     }

--- a/Tests/Web5Tests/Crypto/DigitalSignatureAlgorithms/EdDSA+Ed25519Tests.swift
+++ b/Tests/Web5Tests/Crypto/DigitalSignatureAlgorithms/EdDSA+Ed25519Tests.swift
@@ -12,7 +12,7 @@ final class EdDSA_Ed25519Tests: XCTestCase {
 
         XCTAssertEqual(privateKey.keyType, .octetKeyPair)
         XCTAssertEqual(privateKey.curve, .ed25519)
-        XCTAssertNotNil(privateKey.keyIdentifier)
+        XCTAssertNotNil(privateKey.keyID)
         XCTAssertNotNil(privateKey.d)
         XCTAssertNotNil(privateKey.x)
         XCTAssertNil(privateKey.y)
@@ -28,14 +28,14 @@ final class EdDSA_Ed25519Tests: XCTestCase {
 
         XCTAssertEqual(publicKey.keyType, .octetKeyPair)
         XCTAssertEqual(publicKey.curve, .ed25519)
-        XCTAssertNotNil(publicKey.keyIdentifier)
+        XCTAssertNotNil(publicKey.keyID)
         XCTAssertNil(publicKey.d)
         XCTAssertNotNil(publicKey.x)
         XCTAssertNil(publicKey.y)
 
         XCTAssertEqual(publicKey.curve, privateKey.curve)
         XCTAssertEqual(publicKey.keyType, privateKey.keyType)
-        XCTAssertEqual(publicKey.keyIdentifier, privateKey.keyIdentifier)
+        XCTAssertEqual(publicKey.keyID, privateKey.keyID)
         XCTAssertEqual(publicKey.x, privateKey.x)
         XCTAssertEqual(publicKey.y, privateKey.y)
     }


### PR DESCRIPTION
`JWK` and `JWS` currently use different property names to refer to their `kid` header values:
* `JWK` uses "keyIdentifier"
* `JWS` uses "keyID"

In the specs, both of them use the long form name of "key ID" to refer to the `kid` value:
* [JWK spec](https://datatracker.ietf.org/doc/html/rfc7517#section-4.5)
* [JWS spec](https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.4)

This PR standardizes on this naming convention!