### PR TITLE
Implement JWS.sign & JWS.verify

### DIFF
--- a/Sources/Web5/Dids/BearerDID.swift
+++ b/Sources/Web5/Dids/BearerDID.swift
@@ -71,7 +71,11 @@ public struct BearerDID {
         }
 
         let keyAlias = try keyManager.getDeterministicAlias(key: publicKey)
-        return BearerDIDSigner(keyAlias: keyAlias, keyManager: keyManager)
+        return BearerDIDSigner(
+            keyAlias: keyAlias,
+            keyManager: keyManager,
+            verificationMethod: verificationMethod
+        )
     }
 
     /// Exports the `BearerDID` into a portable format that contains the DID's URI in addition
@@ -137,6 +141,7 @@ public struct BearerDIDSigner {
 
     let keyAlias: String
     let keyManager: KeyManager
+    let verificationMethod: VerificationMethod
 
     public func sign<P>(payload: P) throws -> Data
     where P: DataProtocol {

--- a/Tests/Web5Tests/Crypto/JOSE/JWSTests.swift
+++ b/Tests/Web5Tests/Crypto/JOSE/JWSTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import Web5
+
+final class JWSTests: XCTestCase {
+
+    let did = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+    let payload = "Hello, World!".data(using: .utf8)!
+
+    func test_sign_detachedPayload() throws {
+        let compactJWS = try JWS.sign(did: did, payload: payload, detached: true)
+        let compactJWSParts = compactJWS.split(separator: ".", omittingEmptySubsequences: false)
+
+        XCTAssertEqual(compactJWSParts.count, 3)
+        // Payload (second part) should be empty, as the payload is detached
+        XCTAssertTrue(compactJWSParts[1].isEmpty)
+    }
+
+    func test_sign_attachedPayload() throws {
+        let compactJWS = try JWS.sign(did: did, payload: payload, detached: false)
+        let compactJWSParts = compactJWS.split(separator: ".", omittingEmptySubsequences: false)
+
+        XCTAssertEqual(compactJWSParts.count, 3)
+        // Payload (second part) should NOT be empty, as the payload is attached
+        XCTAssertFalse(compactJWSParts[1].isEmpty)
+    }
+
+    func test_verify_detachedPayload() async throws {
+        let compactJWS = try JWS.sign(did: did, payload: payload, detached: true)
+        let isValid = try await JWS.verify(compactJWS: compactJWS, detachedPayload: payload)
+
+        XCTAssertTrue(isValid)
+    }
+
+    func test_verify_attachedPayload() async throws {
+        let compactJWS = try JWS.sign(did: did, payload: payload, detached: false)
+        let isValid = try await JWS.verify(compactJWS: compactJWS)
+
+        XCTAssertTrue(isValid)
+    }
+
+    func test_verify_expectedSigningDIDURI_match() async throws {
+        let compactJWS = try JWS.sign(did: did, payload: payload, detached: false)
+        let isValid = try await JWS.verify(compactJWS: compactJWS, expectedSigningDIDURI: did.uri)
+
+        XCTAssertTrue(isValid)
+    }
+
+    func test_verify_expectedSigningDIDURI_noMatch() async throws {
+        let compactJWS = try JWS.sign(did: did, payload: payload, detached: false)
+        let isValid = try await JWS.verify(compactJWS: compactJWS, expectedSigningDIDURI: "did:example:1234")
+
+        // compactJWS was signed by `did`, but we're expecting it to be signed by a different DID.
+        // This should result in an invalid signature.
+        XCTAssertFalse(isValid)
+    }
+}


### PR DESCRIPTION
Currently in Swift, JWS signing and verification is done within `tbdex-swift` in a `CryptoUtils` class ([link to current implementation](https://github.com/TBD54566975/tbdex-swift/blob/52b884880cce94c1d808be9dadc8359211fc40d4/Sources/tbDEX/Protocol/CryptoUtils.swift))

This JWS signing and verification is really not specific to tbDEX at all, and having it within that repository seemed really wrong to me. So, this PR brings that code into `web5-swift`, implementing two functions on the already existing `JWS` interface:

## `JWS.sign`

This is a static function that uses a `BearerDID` to sign a given payload, and returns a compact JWS. This function is configurable with the following parameters:
* `detached` - Boolean indicating if the payload in the resulting compact JWS is attached or detached
* `verificationMethodID` - An optional `VerificationMethod` identifier to use for the signing operation. If the provided value does not correlate to a valid `VerificationMethod`, the sign function will throw.

Example usage:
```swift
let did = try DIDJWK.create(keyManager: InMemoryKeyManager())
let payload = "Hello, World!".data(using: .utf8)!
let compactJWS = try JWS.sign(did: did, payload: payload, detached: false)
```

## `JWS.verify`
This is a static function that takes in a `compactJWS` and verifies the integrity of the signature. This function is configurable with the following parameters:
* `detachedPayload` - An optional payload that represented the detached payload signed by the `compactJWS`. If provided, and the `compactJWS` contains an attached payload, the function will throw as you can't have an attached payload and a detached payload.
* `expectedSigningDIDURI` - DID URI of who the caller *expects* the `compactJWS` to be signed by. If provided, and the `compactJWS` was NOT signed by this DID, the function will return false.

Example usage:
```swift
let did = try DIDJWK.create(keyManager: InMemoryKeyManager())
let payload = "Hello, World!".data(using: .utf8)!
let compactJWS = try JWS.sign(did: did, payload: payload, detached: false)
let isValid = try await JWS.verify(compactJWS: compactJWS, expectedSigningDIDURI: did.uri)
```