### PR TITLE
DIDMethodResolver

### DIFF
--- a/Sources/Web5/Dids/Methods/DIDIon.swift
+++ b/Sources/Web5/Dids/Methods/DIDIon.swift
@@ -38,6 +38,8 @@ extension DIDIon {
 
         // MARK: Properties
 
+        public let methodName = DIDIon.methodName
+
         /// The options to use for resolution process
         public let options: ResolutionOptions
 

--- a/Sources/Web5/Dids/Methods/DIDIon.swift
+++ b/Sources/Web5/Dids/Methods/DIDIon.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 /// `did:ion` DID Method
-public enum DIDIon {}
+public enum DIDIon: DIDMethod {
+
+    public static let methodName = "ion"
+
+}
 
 // MARK: - Resolver
 
@@ -9,6 +13,8 @@ extension DIDIon {
     
     /// Resolver for the `did:ion` DID method
     public struct Resolver: DIDMethodResolver {
+
+        // MARK: Types
 
         /// Options that can be configured for resolving `did:ion` DIDs
         public struct ResolutionOptions {
@@ -30,6 +36,13 @@ extension DIDIon {
             )
         }
 
+        // MARK: Properties
+
+        /// The options to use for resolution process
+        public let options: ResolutionOptions
+
+        // MARK: Lifecycle
+
         /// Initialize a new `DIDIon.Resolver`
         /// - Parameters:
         ///   - options: The options to use for resolution process
@@ -39,12 +52,7 @@ extension DIDIon {
             self.options = options
         }
 
-        /// The options to use for resolution process
-        public let options: ResolutionOptions
-
-        // MARK: DIDMethodResolver
-
-        public let methodName = "ion"
+        // MARK: Public Functions
 
         /// Resolves a `did:ion` URI into a `DIDResolutionResult`
         /// - Parameters:

--- a/Sources/Web5/Dids/Methods/DIDIon.swift
+++ b/Sources/Web5/Dids/Methods/DIDIon.swift
@@ -43,7 +43,7 @@ extension DIDIon {
 
         // MARK: Lifecycle
 
-        /// Initialize a new `DIDIon.Resolver`
+        /// Initialize a new resolver for the `did:ion` method
         /// - Parameters:
         ///   - options: The options to use for resolution process
         public init(

--- a/Sources/Web5/Dids/Methods/DIDIon.swift
+++ b/Sources/Web5/Dids/Methods/DIDIon.swift
@@ -1,36 +1,77 @@
 import Foundation
 
 /// `did:ion` DID Method
-public enum DIDIon {
+public enum DIDIon {}
 
-    public static let methodName = "ion"
+// MARK: - Resolver
 
-    /// Resolves a `did:ion` URI into a `DIDResolutionResult`
-    /// - Parameters:
-    ///   - didURI: The DID URI to resolve
-    /// - Returns: `DIDResolutionResult` containing the resolved DID Document.
-    public static func resolve(
-        didURI: String
-    ) async -> DIDResolutionResult {
-        guard let did = try? DID(didURI: didURI) else {
-            return DIDResolutionResult(error: .invalidDID)
+extension DIDIon {
+    
+    /// Resolver for the `did:ion` DID method
+    public struct Resolver: DIDMethodResolver {
+
+        /// Options that can be configured for resolving `did:ion` DIDs
+        public struct ResolutionOptions {
+
+            /// The URI of a server involved in executing DID method operations. In the context of
+            /// DID creation, the endpoint is expected to be a Sidetree node.
+            public let gatewayURI: String
+
+            /// Public Memberwise Initializer
+            public init(
+                gatewayURI: String
+            ) {
+                self.gatewayURI = gatewayURI
+            }
+
+            /// Default ResolutionOptions
+            public static let `default` = ResolutionOptions(
+                gatewayURI: "https://ion.tbddev.org"
+            )
         }
 
-        guard did.methodName == Self.methodName else {
-            return DIDResolutionResult(error: .methodNotSupported)
+        /// Initialize a new `DIDIon.Resolver`
+        /// - Parameters:
+        ///   - options: The options to use for resolution process
+        public init(
+            options: ResolutionOptions = .default
+        ) {
+            self.options = options
         }
 
-        let identifiersEndpoint = "https://ion.tbddev.org/identifiers"
-        guard let url = URL(string: "\(identifiersEndpoint)/\(did.uri)") else {
-            return DIDResolutionResult(error: .notFound)
-        }
+        /// The options to use for resolution process
+        public let options: ResolutionOptions
 
-        do {
-            let response = try await URLSession.shared.data(from: url)
-            let resolutionResult = try JSONDecoder().decode(DIDResolutionResult.self, from: response.0)
-            return resolutionResult
-        } catch {
-            return DIDResolutionResult(error: .notFound)
+        // MARK: DIDMethodResolver
+
+        public let methodName = "ion"
+
+        /// Resolves a `did:ion` URI into a `DIDResolutionResult`
+        /// - Parameters:
+        ///   - didURI: The DID URI to resolve
+        /// - Returns: `DIDResolutionResult` containing the resolved DID Document.
+        public func resolve(
+            didURI: String
+        ) async -> DIDResolutionResult {
+            guard let did = try? DID(didURI: didURI) else {
+                return DIDResolutionResult(error: .invalidDID)
+            }
+
+            guard did.methodName == methodName else {
+                return DIDResolutionResult(error: .methodNotSupported)
+            }
+
+            guard let url = URL(string: "\(options.gatewayURI)/identifiers/\(did.uri)") else {
+                return DIDResolutionResult(error: .notFound)
+            }
+
+            do {
+                let response = try await URLSession.shared.data(from: url)
+                let resolutionResult = try JSONDecoder().decode(DIDResolutionResult.self, from: response.0)
+                return resolutionResult
+            } catch {
+                return DIDResolutionResult(error: .notFound)
+            }
         }
     }
 }

--- a/Sources/Web5/Dids/Methods/DIDJWK.swift
+++ b/Sources/Web5/Dids/Methods/DIDJWK.swift
@@ -5,27 +5,6 @@ public enum DIDJWK {
 
     public static let methodName = "jwk"
 
-    /// Resolves a `did:jwk` URI into a `DIDResolutionResult`
-    /// - Parameters:
-    ///   - didURI: The DID URI to resolve
-    /// - Returns: `DIDResolution.Result` containing the resolved DID Document
-    public static func resolve(
-        didURI: String
-    ) async -> DIDResolutionResult {
-        guard let did = try? DID(didURI: didURI),
-            let jwk = try? JSONDecoder().decode(Jwk.self, from: try did.identifier.decodeBase64Url())
-        else {
-            return DIDResolutionResult(error: .invalidDID)
-        }
-
-        guard did.methodName == self.methodName else {
-            return DIDResolutionResult(error: .methodNotSupported)
-        }
-
-        let didDocument = didDocument(did: did, publicKey: jwk)
-        return DIDResolutionResult(didDocument: didDocument)
-    }
-
     /// Options that can be provided to customize how a `did:jwk` is created
     public struct CreateOptions {
 
@@ -125,6 +104,43 @@ public enum DIDJWK {
             capabilityDelegation: [.referenced(verifiationMethod.id)],
             capabilityInvocation: [.referenced(verifiationMethod.id)]
         )
+    }
+}
+
+// MARK: - Resolver
+
+extension DIDJWK {
+
+    /// Resolver for the `did:jwk` method
+    public struct Resolver: DIDMethodResolver {
+
+        // MARK: Lifecycle
+
+        /// Initialize a new resolver for the `did:jwk` method
+        public init() {}
+
+        // MARK: Public Functions
+
+        /// Resolves a `did:jwk` URI into a `DIDResolutionResult`
+        /// - Parameters:
+        ///   - didURI: The DID URI to resolve
+        /// - Returns: `DIDResolution.Result` containing the resolved DID Document
+        public func resolve(
+            didURI: String
+        ) async -> DIDResolutionResult {
+            guard let did = try? DID(didURI: didURI),
+                let jwk = try? JSONDecoder().decode(Jwk.self, from: try did.identifier.decodeBase64Url())
+            else {
+                return DIDResolutionResult(error: .invalidDID)
+            }
+
+            guard did.methodName == methodName else {
+                return DIDResolutionResult(error: .methodNotSupported)
+            }
+
+            let didDocument = didDocument(did: did, publicKey: jwk)
+            return DIDResolutionResult(didDocument: didDocument)
+        }
     }
 }
 

--- a/Sources/Web5/Dids/Methods/DIDJWK.swift
+++ b/Sources/Web5/Dids/Methods/DIDJWK.swift
@@ -114,6 +114,10 @@ extension DIDJWK {
     /// Resolver for the `did:jwk` method
     public struct Resolver: DIDMethodResolver {
 
+        // MARK: Properties
+
+        public let methodName = DIDJWK.methodName
+
         // MARK: Lifecycle
 
         /// Initialize a new resolver for the `did:jwk` method

--- a/Sources/Web5/Dids/Methods/DIDWeb.swift
+++ b/Sources/Web5/Dids/Methods/DIDWeb.swift
@@ -1,55 +1,66 @@
 import Foundation
 
 /// `did:web` DID Method
-enum DIDWeb {
+enum DIDWeb {}
 
-    public static let methodName = "web"
+// MARK: - Resolver
 
-    /// Resolves a `did:web` URI into a `DIDResolutionResult`
-    /// - Parameters:
-    ///   - didURI: The DID URI to resolve
-    /// - Returns: `DIDResolution.Result` containing the resolved DID Document
-    static func resolve(
-        didURI: String
-    ) async -> DIDResolutionResult {
-        guard let did = try? DID(didURI: didURI),
-            let url = getDIDDocumentUrl(did: did)
-        else {
-            return DIDResolutionResult(error: .invalidDID)
+extension DIDWeb {
+
+    /// Resolver fo the `did:web` DID method
+    public struct Resolver: DIDMethodResolver {
+
+        /// Initialize a new `DIDWeb.Resolver`
+        public init() {}
+
+        // MARK: DIDMethodResolver
+
+        public let methodName = "web"
+
+        /// Resolves a `did:web` URI into a `DIDResolutionResult`
+        /// - Parameters:
+        ///   - didURI: The DID URI to resolve
+        /// - Returns: `DIDResolution.Result` containing the resolved DID Document
+        public func resolve(
+            didURI: String
+        ) async -> DIDResolutionResult {
+            guard let did = try? DID(didURI: didURI),
+                  let url = getDIDDocumentUrl(did: did)
+            else {
+                return DIDResolutionResult(error: .invalidDID)
+            }
+
+            guard did.methodName == methodName else {
+                return DIDResolutionResult(error: .methodNotSupported)
+            }
+
+            do {
+                let response = try await URLSession.shared.data(from: url)
+                let didDocument = try JSONDecoder().decode(DIDDocument.self, from: response.0)
+                return DIDResolutionResult(didDocument: didDocument)
+            } catch {
+                return DIDResolutionResult(error: .notFound)
+            }
         }
 
-        guard did.methodName == Self.methodName else {
-            return DIDResolutionResult(error: .methodNotSupported)
-        }
+        // MARK: Private
 
-        do {
-            let response = try await URLSession.shared.data(from: url)
-            let didDocument = try JSONDecoder().decode(DIDDocument.self, from: response.0)
-            return DIDResolutionResult(didDocument: didDocument)
-        } catch {
-            return DIDResolutionResult(error: .notFound)
+        private func getDIDDocumentUrl(
+            did: DID
+        ) -> URL? {
+            let domainNameWithPath = did.identifier.replacingOccurrences(of: ":", with: "/")
+            guard let decodedDomain = domainNameWithPath.removingPercentEncoding,
+                  var url = URL(string: "https://\(decodedDomain)")
+            else {
+                return nil
+            }
+
+            if url.path.isEmpty {
+                url.appendPathComponent("/.well-known")
+            }
+
+            url.appendPathComponent("/did.json")
+            return url
         }
     }
-
-    private static let wellKnownPath = "/.well-known"
-    private static let didDocumentFilename = "/did.json"
-
-    private static func getDIDDocumentUrl(
-        did: DID
-    ) -> URL? {
-        let domainNameWithPath = did.identifier.replacingOccurrences(of: ":", with: "/")
-        guard let decodedDomain = domainNameWithPath.removingPercentEncoding,
-            var url = URL(string: "https://\(decodedDomain)")
-        else {
-            return nil
-        }
-
-        if url.path.isEmpty {
-            url.appendPathComponent(wellKnownPath)
-        }
-
-        url.appendPathComponent(didDocumentFilename)
-        return url
-    }
-
 }

--- a/Sources/Web5/Dids/Methods/DIDWeb.swift
+++ b/Sources/Web5/Dids/Methods/DIDWeb.swift
@@ -1,7 +1,11 @@
 import Foundation
 
 /// `did:web` DID Method
-enum DIDWeb {}
+enum DIDWeb: DIDMethod {
+    
+    public static let methodName = "web"
+
+}
 
 // MARK: - Resolver
 
@@ -10,12 +14,12 @@ extension DIDWeb {
     /// Resolver fo the `did:web` DID method
     public struct Resolver: DIDMethodResolver {
 
+        // MARK: Lifecycle
+
         /// Initialize a new `DIDWeb.Resolver`
         public init() {}
 
-        // MARK: DIDMethodResolver
-
-        public let methodName = "web"
+        // MARK: Public Functions
 
         /// Resolves a `did:web` URI into a `DIDResolutionResult`
         /// - Parameters:
@@ -43,7 +47,7 @@ extension DIDWeb {
             }
         }
 
-        // MARK: Private
+        // MARK: Private Functions
 
         private func getDIDDocumentUrl(
             did: DID

--- a/Sources/Web5/Dids/Methods/DIDWeb.swift
+++ b/Sources/Web5/Dids/Methods/DIDWeb.swift
@@ -16,7 +16,7 @@ extension DIDWeb {
 
         // MARK: Lifecycle
 
-        /// Initialize a new `DIDWeb.Resolver`
+        /// Initialize a new resolver for the `did:web` method
         public init() {}
 
         // MARK: Public Functions

--- a/Sources/Web5/Dids/Methods/DIDWeb.swift
+++ b/Sources/Web5/Dids/Methods/DIDWeb.swift
@@ -14,6 +14,10 @@ extension DIDWeb {
     /// Resolver fo the `did:web` DID method
     public struct Resolver: DIDMethodResolver {
 
+        // MARK: Properties
+
+        public let methodName = DIDWeb.methodName
+
         // MARK: Lifecycle
 
         /// Initialize a new resolver for the `did:web` method

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethod.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethod.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Protocol defining the behaviors common to all DID methods
+public protocol DIDMethod {
+    
+    /// The name of the DID method that this `DIDMethod` represents
+    ///
+    /// Example: In the DID URI `did:example:123`, the methodName is `example`
+    static var methodName: String { get }
+
+}

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
@@ -3,6 +3,11 @@ import Foundation
 /// Protocol defining the behaviors common to all DID method resolvers
 public protocol DIDMethodResolver {
 
+    /// The name of the DID method that this resolver supports
+    ///
+    /// Example: In the DID URI `did:example:123`, the method name is `example`
+    var methodName: String { get }
+
     /// Resolves a DID URI into a `DIDResolutionResult`
     /// - Parameters:
     ///   - didURI: The DID URI to resolve

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
@@ -3,10 +3,14 @@ import Foundation
 /// Protocol defining the behaviors common to all DID method resolvers
 public protocol DIDMethodResolver {
 
+    /// DID method name that the `DIDMethodResolver` is capable of resolving
+    ///
+    /// Example: In the DID URI `did:example:123`, the methodName is `example`
+    var methodName: String { get }
+
     /// Resolves a DID URI into a `DIDResolutionResult`
     /// - Parameters:
     ///   - didURI: The DID URI to resolve
     /// - Returns: `DIDResolution.Result` containing the resolved DID Document
     func resolve(didURI: String) async -> DIDResolutionResult
-
 }

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Protocol defining the behaviors common to all DID method resolvers
+public protocol DIDMethodResolver {
+
+    /// Resolves a DID URI into a `DIDResolutionResult`
+    /// - Parameters:
+    ///   - didURI: The DID URI to resolve
+    /// - Returns: `DIDResolution.Result` containing the resolved DID Document
+    func resolve(didURI: String) async -> DIDResolutionResult
+
+}

--- a/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
+++ b/Sources/Web5/Dids/Methods/Protocols/DIDMethodResolver.swift
@@ -3,11 +3,6 @@ import Foundation
 /// Protocol defining the behaviors common to all DID method resolvers
 public protocol DIDMethodResolver {
 
-    /// The name of the DID method that this resolver supports
-    ///
-    /// Example: In the DID URI `did:example:123`, the method name is `example`
-    var methodName: String { get }
-
     /// Resolves a DID URI into a `DIDResolutionResult`
     /// - Parameters:
     ///   - didURI: The DID URI to resolve

--- a/Sources/Web5/Dids/Resolution/DIDResolver.swift
+++ b/Sources/Web5/Dids/Resolution/DIDResolver.swift
@@ -1,28 +1,51 @@
 import Foundation
 
-//typealias DIDMethodResolver = (String) async -> DIDResolutionResult
-
 public enum DIDResolver {
 
-//    private static var methodResolvers: [String: DIDMethodResolver] = [
-//        DIDIon.methodName: DIDIon.resolve,
-//        DIDJWK.methodName: DIDJWK.resolve,
-//        DIDWeb.methodName: DIDWeb.resolve,
-//    ]
+    // MARK: Static Properties
+
+    private static var methodResolvers: [String: DIDMethodResolver] = {
+        let defaultResolvers: [DIDMethodResolver] = [
+            DIDJWK.Resolver(),
+            DIDIon.Resolver(),
+            DIDWeb.Resolver()
+        ]
+
+        return defaultResolvers.reduce(into: [String: DIDMethodResolver]()) { result, resolver in
+            result[resolver.methodName] = resolver
+        }
+    }()
+
+    // MARK: Public Static Functions
+
+    /// Register a `DIDMethodResolver` for custom resolution of a DID method.
+    ///
+    /// Certain DID methods can be resolved in a customized fashion, using a different configuration options
+    /// to determine various aspects of the resolution process. If a customized resolution experience is desired,
+    /// create a new `DIDMethodResolver` with the custom configuration options and register it using this function.
+    ///
+    /// If a resolver for the same method name already exists, it will be replaced.
+    ///
+    /// - Parameters:
+    ///   - resolver: The `DIDMethodResolver` to add
+    public static func register(
+        resolver: DIDMethodResolver
+    ) {
+        methodResolvers[resolver.methodName] = resolver
+    }
 
     /// Resolves a DID URI to its DID Document
     public static func resolve(
         didURI: String
     ) async -> DIDResolutionResult {
-//        guard let did = try? DID(didURI: didURI) else {
-//            return DIDResolutionResult(error: .invalidDID)
-//        }
-//
-//        guard let methodResolver = methodResolvers[did.methodName] else {
-//            return DIDResolutionResult(error: .methodNotSupported)
-//        }
-//
-//        return await methodResolver(didURI)
-        fatalError("Not implemented")
+        guard let did = try? DID(didURI: didURI) else {
+            return DIDResolutionResult(error: .invalidDID)
+        }
+
+        guard let methodResolver = methodResolvers[did.methodName] else {
+            return DIDResolutionResult(error: .methodNotSupported)
+        }
+
+        return await methodResolver.resolve(didURI: didURI)
     }
 }

--- a/Sources/Web5/Dids/Resolution/DIDResolver.swift
+++ b/Sources/Web5/Dids/Resolution/DIDResolver.swift
@@ -1,27 +1,28 @@
 import Foundation
 
-typealias DIDMethodResolver = (String) async -> DIDResolutionResult
+//typealias DIDMethodResolver = (String) async -> DIDResolutionResult
 
 public enum DIDResolver {
 
-    private static var methodResolvers: [String: DIDMethodResolver] = [
-        DIDIon.methodName: DIDIon.resolve,
-        DIDJWK.methodName: DIDJWK.resolve,
-        DIDWeb.methodName: DIDWeb.resolve,
-    ]
+//    private static var methodResolvers: [String: DIDMethodResolver] = [
+//        DIDIon.methodName: DIDIon.resolve,
+//        DIDJWK.methodName: DIDJWK.resolve,
+//        DIDWeb.methodName: DIDWeb.resolve,
+//    ]
 
     /// Resolves a DID URI to its DID Document
     public static func resolve(
         didURI: String
     ) async -> DIDResolutionResult {
-        guard let did = try? DID(didURI: didURI) else {
-            return DIDResolutionResult(error: .invalidDID)
-        }
-
-        guard let methodResolver = methodResolvers[did.methodName] else {
-            return DIDResolutionResult(error: .methodNotSupported)
-        }
-
-        return await methodResolver(didURI)
+//        guard let did = try? DID(didURI: didURI) else {
+//            return DIDResolutionResult(error: .invalidDID)
+//        }
+//
+//        guard let methodResolver = methodResolvers[did.methodName] else {
+//            return DIDResolutionResult(error: .methodNotSupported)
+//        }
+//
+//        return await methodResolver(didURI)
+        fatalError("Not implemented")
     }
 }

--- a/Tests/Web5TestVectors/Web5TestVectorsDidJwk.swift
+++ b/Tests/Web5TestVectors/Web5TestVectorsDidJwk.swift
@@ -11,11 +11,13 @@ final class Web5TestVectorsDidJwk: XCTestCase {
             subdirectory: "test-vectors/did_jwk"
         )
 
+        let resolver = DIDJWK.Resolver()
+
         testVector.run { vector in
             let expectation = XCTestExpectation(description: "async resolve")
             Task {
                 let didURI = vector.input
-                let result = await DIDJWK.resolve(didURI: didURI)
+                let result = await resolver.resolve(didURI: didURI)
                 XCTAssertNoDifference(result, vector.output)
                 expectation.fulfill()
             }

--- a/Tests/Web5TestVectors/Web5TestVectorsDidWeb.swift
+++ b/Tests/Web5TestVectors/Web5TestVectorsDidWeb.swift
@@ -15,10 +15,9 @@ final class Web5TestVectorsDidWeb: XCTestCase {
                 guard let mockServer = mockServer else { return [] }
 
                 return try mockServer.map({ key, value in
-                    print("Mocking \(key)")
                     return Mock(
                         url: URL(string: key)!,
-                        dataType: .json,
+                        contentType: .json,
                         statusCode: 200,
                         data: [
                             .get: try JSONEncoder().encode(value)
@@ -33,6 +32,8 @@ final class Web5TestVectorsDidWeb: XCTestCase {
             subdirectory: "test-vectors/did_web"
         )
 
+        let resolver = DIDWeb.Resolver()
+
         testVector.run { vector in
             let expectation = XCTestExpectation(description: "async resolve")
             Task {
@@ -40,7 +41,7 @@ final class Web5TestVectorsDidWeb: XCTestCase {
                 try vector.input.mocks().forEach { $0.register() }
 
                 /// Resolve each input didURI, make sure it matches output
-                let result = await DIDWeb.resolve(didURI: vector.input.didUri)
+                let result = await resolver.resolve(didURI: vector.input.didUri)
                 XCTAssertNoDifference(result, vector.output)
                 expectation.fulfill()
             }

--- a/Tests/Web5Tests/Dids/DIDJWKTests.swift
+++ b/Tests/Web5Tests/Dids/DIDJWKTests.swift
@@ -5,6 +5,8 @@ import XCTest
 
 final class DIDJWKTests: XCTestCase {
 
+    let resolver = DIDJWK.Resolver()
+
     func test_create() throws {
         let keyManager = InMemoryKeyManager()
         let didJwk = try DIDJWK.create(keyManager: keyManager)
@@ -13,28 +15,28 @@ final class DIDJWKTests: XCTestCase {
     }
 
     func test_resolveWithError_onInvalidDIDURI() async throws {
-        let resolutionResult = await DIDJWK.resolve(didURI: "hi")
+        let resolutionResult = await resolver.resolve(didURI: "hi")
 
         XCTAssertNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DIDResolutionResult.Error.invalidDID.rawValue)
     }
 
     func test_resolveWithError_ifDIDURINotJwk() async {
-        let resolutionResult = await DIDJWK.resolve(didURI: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
+        let resolutionResult = await resolver.resolve(didURI: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
 
         XCTAssertNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DIDResolutionResult.Error.invalidDID.rawValue)
     }
 
     func test_resolveWithError_ifDIDURIIsNotValidBase64Url() async {
-        let resolutionResult = await DIDJWK.resolve(didURI: "did:jwk:!!!")
+        let resolutionResult = await resolver.resolve(didURI: "did:jwk:!!!")
 
         XCTAssertNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DIDResolutionResult.Error.invalidDID.rawValue)
     }
 
     func test_resolveWithError_ifMethodNotJwk() async {
-        let resolutionResult = await DIDJWK.resolve(
+        let resolutionResult = await resolver.resolve(
             didURI:
                 "did:web:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ"
         )
@@ -48,7 +50,7 @@ final class DIDJWKTests: XCTestCase {
         let keyManager = InMemoryKeyManager()
         let didJWK = try DIDJWK.create(keyManager: keyManager)
 
-        let resolutionResult = await DIDJWK.resolve(didURI: didJWK.uri)
+        let resolutionResult = await resolver.resolve(didURI: didJWK.uri)
         XCTAssertNotNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didDocument?.id, didJWK.uri)
         XCTAssertEqual(resolutionResult.didDocument?.verificationMethod?.first?.id, "\(didJWK.uri)#0")
@@ -62,7 +64,7 @@ final class DIDJWKTests: XCTestCase {
     func test_resolveWithKnownDIDURI() async {
         let didURI =
             "did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ"
-        let resolutionResult = await DIDJWK.resolve(didURI: didURI)
+        let resolutionResult = await resolver.resolve(didURI: didURI)
 
         XCTAssertNotNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didDocument?.id, didURI)


### PR DESCRIPTION
My previous attempt at adding a `DIDMethodResolver` protocol in https://github.com/TBD54566975/web5-swift/pull/9 didn't really work out how I intended it to, so I reverted it. 

This PR re-introduces a `DIDMethodResolver` protocol, and handles the behaviors of a DID resolver much better.

## `DIDMethodResolver`

`DIDMethodResolver` is a new protocol that defines what's required to resolve a DID method. There are two things:
1. the `methodName` that's being resolved
2. a `func resolve(didURI: String) -> ResolutionResult` function

Each DID method implements this `DIDMethodResolver` with a struct. This struct can then initiated and registered  with `DIDResolver`, to customize the resolution experience for any SDK consumer's use case.

## `DIDResolver`

`DIDResolver` now has a new function available on it:
`public static func register(resolver: DIDMethodResolver)`

This is how an SDK consumer can customize the behavior of the resolution of any DID Method. For example, if a user wanted to customize the experience of resolving `did:ion`, they would do the following:

```
let resolver = DIDIon.Resolver(options: .init(gatewayURI: "https://my-custom-gateway.org"))
DIDResolver.register(resolver: resolver)
```