### PR TITLE
 Record test coverage, upload it to codecov.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,17 @@ jobs:
       run: swift build
 
     - name: Run tests
-      run: swift test
+      run: swift test --enable-code-coverage
+    
+    - name: Convert the coverage data
+      run: llvm-cov export -format="lcov" .build/x86_64-apple-macosx/debug/Web5PackageTests.xctest/Contents/MacOS/Web5PackageTests -instr-profile .build/x86_64-apple-macosx/debug/codecov/default.profdata > info.lcov
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@c16abc29c95fcf9174b58eb7e1abf4c866893bc8 # 4.1.1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: TBD54566975/web5-swift
+        files: info.lcov
 
     - uses: actions/upload-artifact@v3
       with:


### PR DESCRIPTION
not sure why swift packages were missing from codecov before, this should fix for this repo.